### PR TITLE
Add warning popup for portrait orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,8 @@
         if ( screen.availWidth < screen.availHeight )
             alert( "It is not recommended to play MUME with a portrait orientation. "
                  + "If on a mobile device, consider playing in landscape mode with an external keyboard"
-                 + " or on a desktop device for a better experience." );
+                 + " or on a desktop device for a better experience. "
+                 + "If on a vertical monitor, consider \"popping out\" (Options > Detach Map) the map." );
     </script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -156,6 +156,11 @@
             if ( globalMapWindow != undefined )
                 globalMapWindow.close();
         } );
+
+        if ( screen.availWidth < screen.availHeight )
+            alert( "It is not recommended to play MUME with a portrait orientation. "
+                 + "If on a mobile device, consider playing in landscape mode with an external keyboard"
+                 + " or on a desktop device for a better experience." );
     </script>
 </head>
 <body>


### PR DESCRIPTION
Addresses #4 

Adds a warning when portrait orientation ("screen width" < "screen height") is detected.
The warning message suggests using a physical keyboard in landscape orientation for mobile devices, and detaching the map to a separate window. 

Possible improvements include detecting width in characters and using that to display the warning instead. 