### PR TITLE
Removed obsolete `version` field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   play-mume:
     build:


### PR DESCRIPTION
Docker-Compose emits a warning "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion" upon setting up the environment. This commit removes that obsolete field. 