### PR TITLE
fix numpad movement and function key macros

### DIFF
--- a/src/mume.macros.ts
+++ b/src/mume.macros.ts
@@ -4,7 +4,6 @@
  * This file is originally from Discworld.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Potentially used by global event handlers or index.html
 function tryExtraMacro(decaf: DecafMUDInstance, keycode: number): number {
   // f-key macros
   if (112 <= keycode && keycode <= 121 && fkeys_enabled()) {
@@ -40,3 +39,5 @@ function tryExtraMacro(decaf: DecafMUDInstance, keycode: number): number {
   // anything else (not handled)
   return 0;
 }
+
+window.tryExtraMacro = tryExtraMacro;

--- a/src/window-extensions.d.ts
+++ b/src/window-extensions.d.ts
@@ -41,6 +41,7 @@ declare global {
     mume_menu_rules?: () => void;
     mume_menu_about_map?: () => void;
     mume_menu_map_bug?: () => void;
+    tryExtraMacro?: (decaf: DecafMUDInstance, keycode: number) => number;
   }
 
 }


### PR DESCRIPTION
## Summary by Sourcery

Expose the extra macro handler on the global window object so numpad and function key macros can be triggered from external event handlers.

Bug Fixes:
- Restore proper handling of numpad and function key macros by making the macro function available to global key event logic.

Enhancements:
- Register tryExtraMacro on the window object to make it globally accessible for macro handling.